### PR TITLE
Added ready up and implemented some actions

### DIFF
--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -18,7 +18,18 @@ G.LOBBY = {
 	is_host = false,
 }
 
+PREV_ACHIEVEMENT_VALUE = true
 function G.MULTIPLAYER.update_connection_status()
+	-- Save the previous value of the achievement flag
+	PREV_ACHIEVEMENT_VALUE = G.F_NO_ACHIEVEMENTS
+	if G.LOBBY.connected then
+		-- Disable achievements when connected to server
+		G.F_NO_ACHIEVEMENTS = true
+	else
+		-- Restore them when disconnected
+		G.F_NO_ACHIEVEMENTS = PREV_ACHIEVEMENT_VALUE
+	end
+
 	if G.HUD_connection_status then
 		G.HUD_connection_status:remove()
 	end
@@ -43,7 +54,10 @@ end
 
 function G.MULTIPLAYER.update_player_usernames()
 	if G.LOBBY.code then
-		G.MAIN_MENU_UI:remove()
+		if G.MAIN_MENU_UI then
+			G.MAIN_MENU_UI:remove()
+		end
+
 		G.FUNCS.display_lobby_main_menu_UI()
 	end
 end

--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -18,6 +18,11 @@ G.LOBBY = {
 	is_host = false,
 }
 
+G.MULTIPLAYER_GAME = {
+	ready = false,
+	ready_text = "Ready",
+}
+
 PREV_ACHIEVEMENT_VALUE = true
 function G.MULTIPLAYER.update_connection_status()
 	-- Save the previous value of the achievement flag

--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -19,8 +19,8 @@ G.LOBBY = {
 }
 
 G.MULTIPLAYER_GAME = {
-	ready = false,
-	ready_text = "Ready",
+	ready_blind = false,
+	ready_blind_text = "Ready",
 }
 
 PREV_ACHIEVEMENT_VALUE = true

--- a/Multiplayer/Networking/Action_Handlers.lua
+++ b/Multiplayer/Networking/Action_Handlers.lua
@@ -41,6 +41,9 @@ local function action_lobbyInfo(host, guest, is_host)
 	else
 		G.LOBBY.guest = {}
 	end
+	-- TODO: This should check for player count instead
+	-- once we enable more than 2 players
+	G.LOBBY.ready_to_start = G.LOBBY.is_host and guest ~= nil
 	G.MULTIPLAYER.update_player_usernames()
 end
 
@@ -81,6 +84,10 @@ function G.MULTIPLAYER.leave_lobby()
 	Client.send("action:leaveLobby")
 end
 
+function G.MULTIPLAYER.start_game()
+	Client.send("action:startGame")
+end
+
 -- Utils
 function G.MULTIPLAYER.connect()
 	Client.send("connect")
@@ -114,6 +121,11 @@ function Game:update(dt)
 				action_joinedLobby(parsedAction.code)
 			elseif parsedAction.action == "lobbyInfo" then
 				action_lobbyInfo(parsedAction.host, parsedAction.guest, parsedAction.isHost)
+			elseif parsedAction.action == "startGame" then
+				G.FUNCS.lobby_start_run(
+					nil,
+					{ deck = parsedAction.deck, seed = parsedAction.seed, stake = parsedAction.stake }
+				)
 			elseif parsedAction.action == "error" then
 				action_error(parsedAction.message)
 			elseif parsedAction.action == "keepAlive" then

--- a/Multiplayer/Networking/Action_Handlers.lua
+++ b/Multiplayer/Networking/Action_Handlers.lua
@@ -88,6 +88,14 @@ function G.MULTIPLAYER.start_game()
 	Client.send("action:startGame")
 end
 
+function G.MULTIPLAYER.playerReady()
+	Client.send("action:playerReady")
+end
+
+function G.MULTIPLAYER.playerUnready()
+	Client.send("action:playerUnready")
+end
+
 -- Utils
 function G.MULTIPLAYER.connect()
 	Client.send("connect")
@@ -126,6 +134,11 @@ function Game:update(dt)
 					nil,
 					{ deck = parsedAction.deck, seed = parsedAction.seed, stake = parsedAction.stake }
 				)
+			elseif parsedAction.action == "startBlind" then
+				G.MULTIPLAYER_GAME.ready = false
+				-- TODO: This should check that player is in a
+				-- multiplayer game
+				G.FUNCS.toggle_shop()
 			elseif parsedAction.action == "error" then
 				action_error(parsedAction.message)
 			elseif parsedAction.action == "keepAlive" then

--- a/Multiplayer/Networking/Action_Handlers.lua
+++ b/Multiplayer/Networking/Action_Handlers.lua
@@ -88,12 +88,12 @@ function G.MULTIPLAYER.start_game()
 	Client.send("action:startGame")
 end
 
-function G.MULTIPLAYER.playerReady()
-	Client.send("action:playerReady")
+function G.MULTIPLAYER.readyBlind()
+	Client.send("action:readyBlind")
 end
 
-function G.MULTIPLAYER.playerUnready()
-	Client.send("action:playerUnready")
+function G.MULTIPLAYER.unreadyBlind()
+	Client.send("action:unreadyBlind")
 end
 
 -- Utils
@@ -135,7 +135,7 @@ function Game:update(dt)
 					{ deck = parsedAction.deck, seed = parsedAction.seed, stake = parsedAction.stake }
 				)
 			elseif parsedAction.action == "startBlind" then
-				G.MULTIPLAYER_GAME.ready = false
+				G.MULTIPLAYER_GAME.ready_blind = false
 				-- TODO: This should check that player is in a
 				-- multiplayer game
 				G.FUNCS.toggle_shop()

--- a/Multiplayer/UI/Game_UI.lua
+++ b/Multiplayer/UI/Game_UI.lua
@@ -615,21 +615,21 @@ local function reset_blind_HUD()
 end
 
 function G.FUNCS.mp_toggle_ready(e)
-	G.MULTIPLAYER_GAME.ready = not G.MULTIPLAYER_GAME.ready
-	G.MULTIPLAYER_GAME.ready_text = G.MULTIPLAYER_GAME.ready and "Unready" or "Ready"
+	G.MULTIPLAYER_GAME.ready_blind = not G.MULTIPLAYER_GAME.ready_blind
+	G.MULTIPLAYER_GAME.ready_blind_text = G.MULTIPLAYER_GAME.ready_blind and "Unready" or "Ready"
 
-	if G.MULTIPLAYER_GAME.ready then
-		G.MULTIPLAYER.playerReady()
+	if G.MULTIPLAYER_GAME.ready_blind then
+		G.MULTIPLAYER.readyBlind()
 	else
-		G.MULTIPLAYER.playerUnready()
+		G.MULTIPLAYER.unreadyBlind()
 	end
 end
 
-function G.FUNCS.mp_config_ready_button(e)
+function G.FUNCS.mp_cfg_ready_blind_button(e)
 	-- Override next round button
 	e.config.ref_table = G.FUNCS
 	e.config.button = "mp_toggle_ready"
-	e.config.colour = G.MULTIPLAYER_GAME.ready and G.C.GREEN or G.C.RED
+	e.config.colour = G.MULTIPLAYER_GAME.ready_blind and G.C.GREEN or G.C.RED
 	e.config.one_press = false
 end
 
@@ -694,7 +694,7 @@ function G.UIDEF.shop()
 	local inner_table = t.nodes[1].nodes[1].nodes[1].nodes
 
 	local next_round_button = inner_table[1].nodes[1].nodes[1].nodes[1]
-	next_round_button.config.func = "mp_config_ready_button"
+	next_round_button.config.func = "mp_cfg_ready_blind_button"
 
 	-- Text inside the button
 	next_round_button.nodes[1].nodes = {
@@ -706,7 +706,7 @@ function G.UIDEF.shop()
 					n = G.UIT.T,
 					config = {
 						ref_table = G.MULTIPLAYER_GAME,
-						ref_value = "ready_text",
+						ref_value = "ready_blind_text",
 						scale = 0.65,
 						colour = G.C.WHITE,
 						shadow = true,

--- a/Multiplayer/UI/Game_UI.lua
+++ b/Multiplayer/UI/Game_UI.lua
@@ -619,9 +619,9 @@ function G.FUNCS.mp_toggle_ready(e)
 	G.MULTIPLAYER_GAME.ready_blind_text = G.MULTIPLAYER_GAME.ready_blind and "Unready" or "Ready"
 
 	if G.MULTIPLAYER_GAME.ready_blind then
-		G.MULTIPLAYER.readyBlind()
+		G.MULTIPLAYER.ready_blind()
 	else
-		G.MULTIPLAYER.unreadyBlind()
+		G.MULTIPLAYER.unready_blind()
 	end
 end
 
@@ -717,6 +717,15 @@ function G.UIDEF.shop()
 	}
 
 	return t
+end
+
+local update_hand_played_ref = Game.update_hand_played
+function Game:update_hand_played(dt)
+	if not G.STATE_COMPLETE then
+		G.MULTIPLAYER.play_hand(G.GAME.chips, G.GAME.current_round.hands_left)
+	end
+
+	update_hand_played_ref(self, dt)
 end
 
 ----------------------------------------------

--- a/Multiplayer/UI/Game_UI.lua
+++ b/Multiplayer/UI/Game_UI.lua
@@ -617,6 +617,12 @@ end
 function G.FUNCS.mp_toggle_ready(e)
 	G.MULTIPLAYER_GAME.ready = not G.MULTIPLAYER_GAME.ready
 	G.MULTIPLAYER_GAME.ready_text = G.MULTIPLAYER_GAME.ready and "Unready" or "Ready"
+
+	if G.MULTIPLAYER_GAME.ready then
+		G.MULTIPLAYER.playerReady()
+	else
+		G.MULTIPLAYER.playerUnready()
+	end
 end
 
 function G.FUNCS.mp_config_ready_button(e)

--- a/Multiplayer/UI/Lobby_UI.lua
+++ b/Multiplayer/UI/Lobby_UI.lua
@@ -123,16 +123,17 @@ function G.UIDEF.create_UIBox_lobby_menu()
 						nodes = {
 							Disableable_Button({
 								id = "lobby_menu_start",
-								button = "lobby_setup_run",
+								button = "lobby_start_game",
 								colour = G.C.BLUE,
 								minw = 3.65,
 								minh = 1.55,
 								label = { "START" },
-								disabled_text = { "WAITING FOR", "HOST TO START" },
+								disabled_text = G.LOBBY.is_host and { "WAITING FOR", "PLAYERS" }
+									or { "WAITING FOR", "HOST TO START" },
 								scale = text_scale * 2,
 								col = true,
 								enabled_ref_table = G.LOBBY,
-								enabled_ref_value = "is_host",
+								enabled_ref_value = "ready_to_start",
 							}),
 							{
 								n = G.UIT.C,
@@ -311,9 +312,11 @@ function G.FUNCS.get_lobby_main_menu_UI(e)
 	})
 end
 
-function G.FUNCS.lobby_setup_run(e)
+---@type fun(e: table | nil, args: { deck: string, stake: number | nil, seed: string | nil })
+function G.FUNCS.lobby_start_run(e, args)
 	G.FUNCS.start_run(e, {
 		stake = 1,
+		seed = args.seed,
 		challenge = {
 			name = "Multiplayer Deck",
 			id = "c_multiplayer_1",
@@ -339,6 +342,10 @@ function G.FUNCS.lobby_setup_run(e)
 			},
 		},
 	})
+end
+
+function G.FUNCS.lobby_start_game(e)
+	G.MULTIPLAYER.start_game()
 end
 
 function G.FUNCS.lobby_options(e)

--- a/Server/README.md
+++ b/Server/README.md
@@ -164,6 +164,16 @@ enemyInfo
 
 ---
 
+playerReady
+- Indicates that player is ready for the next blind.
+
+---
+
+playerUnready
+- Indicates that player is not ready for the next blind.
+
+---
+
 ### Utility
 
 keepAlive

--- a/Server/README.md
+++ b/Server/README.md
@@ -142,6 +142,11 @@ readyBlind
 
 ---
 
+unreadyBlind
+- Declare not ready to start next blind.
+
+---
+
 playHand: score, handsLeft
 - Client has played a hand.
 - score: The total score of all hands played in the blind so far, must be a number
@@ -161,18 +166,6 @@ playerInfo
 
 enemyInfo
 - Request an enemyInfo update.
-
----
-
-playerReady
-- Indicates that player is ready for the next blind.
-
----
-
-playerUnready
-- Indicates that player is not ready for the next blind.
-
----
 
 ### Utility
 

--- a/Server/src/Client.ts
+++ b/Server/src/Client.ts
@@ -9,22 +9,25 @@ type SendFn = (data: string) => void
 type Address = net.AddressInfo | {}
 
 class Client {
+	// Connection info
 	id: string
 	// Could be useful later on to detect reconnects
 	address: Address
-	username: string
-	lobby: Lobby | null
-	/** Whether player is ready for next blind */
-	isReady: boolean
 	send: SendFn
+
+	// Game info
+	username = 'Guest'
+	lobby: Lobby | null = null
+	/** Whether player is ready for next blind */
+	isReady = false
+	// TODO: Set lives based on game mode
+	lives = 4
+	score = 0
 
 	constructor(address: Address, send: SendFn) {
 		this.id = uuidv4()
-		this.lobby = null
-		this.username = 'Guest'
 		this.address = address
 		this.send = send
-		this.isReady = false
 	}
 
 	setUsername = (username: string) => {

--- a/Server/src/Client.ts
+++ b/Server/src/Client.ts
@@ -26,7 +26,7 @@ class Client {
 
 	setUsername = (username: string) => {
 		this.username = username
-		this.lobby?.broadcast()
+		this.lobby?.broadcastLobbyInfo()
 	}
 
 	setLobby = (lobby: Lobby | null) => {

--- a/Server/src/Client.ts
+++ b/Server/src/Client.ts
@@ -14,6 +14,8 @@ class Client {
 	address: Address
 	username: string
 	lobby: Lobby | null
+	/** Whether player is ready for next blind */
+	isReady: boolean
 	send: SendFn
 
 	constructor(address: Address, send: SendFn) {
@@ -22,6 +24,7 @@ class Client {
 		this.username = 'Guest'
 		this.address = address
 		this.send = send
+		this.isReady = false
 	}
 
 	setUsername = (username: string) => {

--- a/Server/src/Lobby.ts
+++ b/Server/src/Lobby.ts
@@ -1,5 +1,5 @@
 import type Client from './Client.js'
-import type { ActionLobbyInfo } from './actions.js'
+import type { Action, ActionLobbyInfo } from './actions.js'
 import { serializeAction } from './main.js'
 
 const Lobbies = new Map()
@@ -45,7 +45,7 @@ class Lobby {
 		if (this.host === null) {
 			Lobbies.delete(this.code)
 		} else {
-			this.broadcast()
+			this.broadcastLobbyInfo()
 		}
 	}
 
@@ -62,10 +62,15 @@ class Lobby {
 		this.guest = client
 		client.setLobby(this)
 		client.send(serializeAction({ action: 'joinedLobby', code: this.code }))
-		this.broadcast()
+		this.broadcastLobbyInfo()
 	}
 
-	broadcast = () => {
+	broadcast = (action: Action) => {
+		this.host?.send(serializeAction(action))
+		this.guest?.send(serializeAction(action))
+	}
+
+	broadcastLobbyInfo = () => {
 		if (!this.host) {
 			return
 		}

--- a/Server/src/actionHandlers.ts
+++ b/Server/src/actionHandlers.ts
@@ -69,6 +69,23 @@ const startGameAction = (client: Client) => {
 	})
 }
 
+const playerReadyAction = (client: Client) => {
+	client.isReady = true
+
+	// TODO: Refactor for more than two players
+	if (client.lobby?.host?.isReady && client.lobby.guest?.isReady) {
+		// Reset ready status for next blind
+		client.lobby.host.isReady = false
+		client.lobby.guest.isReady = false
+
+		client.lobby.broadcast({ action: 'startBlind' })
+	}
+}
+
+const playerUnreadyAction = (client: Client) => {
+	client.isReady = false
+}
+
 // Declared partial for now untill all action handlers are defined
 export const actionHandlers = {
 	username: usernameAction,
@@ -78,4 +95,6 @@ export const actionHandlers = {
 	leaveLobby: leaveLobbyAction,
 	keepAlive: keepAliveAction,
 	startGame: startGameAction,
+	playerReady: playerReadyAction,
+	playerUnready: playerUnreadyAction,
 } satisfies Partial<ActionHandlers>

--- a/Server/src/actionHandlers.ts
+++ b/Server/src/actionHandlers.ts
@@ -46,7 +46,7 @@ const leaveLobbyAction = (client: Client) => {
 }
 
 const lobbyInfoAction = (client: Client) => {
-	client.lobby?.broadcast()
+	client.lobby?.broadcastLobbyInfo()
 }
 
 const keepAliveAction = (client: Client) => {
@@ -54,12 +54,27 @@ const keepAliveAction = (client: Client) => {
 	client.send(serializeAction({ action: 'keepAliveAck' }))
 }
 
+const startGameAction = (client: Client) => {
+	// Only allow the host to start the game
+	if (!client.lobby || client.lobby.host?.id !== client.id) {
+		return
+	}
+
+	// Hardcoded for testing
+	client.lobby.broadcast({
+		action: 'startGame',
+		deck: 'c_multiplayer_1',
+		seed: '7WT7WG5D',
+	})
+}
+
 // Declared partial for now untill all action handlers are defined
-export const actionHandlers: Partial<ActionHandlers> = {
+export const actionHandlers = {
 	username: usernameAction,
 	createLobby: createLobbyAction,
 	joinLobby: joinLobbyAction,
 	lobbyInfo: lobbyInfoAction,
 	leaveLobby: leaveLobbyAction,
 	keepAlive: keepAliveAction,
-}
+	startGame: startGameAction,
+} satisfies Partial<ActionHandlers>

--- a/Server/src/actionHandlers.ts
+++ b/Server/src/actionHandlers.ts
@@ -69,7 +69,7 @@ const startGameAction = (client: Client) => {
 	})
 }
 
-const playerReadyAction = (client: Client) => {
+const readyBlindAction = (client: Client) => {
 	client.isReady = true
 
 	// TODO: Refactor for more than two players
@@ -82,7 +82,7 @@ const playerReadyAction = (client: Client) => {
 	}
 }
 
-const playerUnreadyAction = (client: Client) => {
+const unreadyBlindAction = (client: Client) => {
 	client.isReady = false
 }
 
@@ -95,6 +95,6 @@ export const actionHandlers = {
 	leaveLobby: leaveLobbyAction,
 	keepAlive: keepAliveAction,
 	startGame: startGameAction,
-	playerReady: playerReadyAction,
-	playerUnready: playerUnreadyAction,
+	readyBlind: readyBlindAction,
+	unreadyBlind: unreadyBlindAction,
 } satisfies Partial<ActionHandlers>

--- a/Server/src/actionHandlers.ts
+++ b/Server/src/actionHandlers.ts
@@ -8,6 +8,7 @@ import type {
 	ActionUsername,
 } from './actions.js'
 import { serializeAction } from './main.js'
+import { generateSeed } from './utils.js'
 
 const usernameAction = (
 	{ username }: ActionHandlerArgs<ActionUsername>,
@@ -64,7 +65,7 @@ const startGameAction = (client: Client) => {
 	client.lobby.broadcast({
 		action: 'startGame',
 		deck: 'c_multiplayer_1',
-		seed: '7WT7WG5D',
+		seed: generateSeed(),
 	})
 }
 

--- a/Server/src/actions.ts
+++ b/Server/src/actions.ts
@@ -56,6 +56,7 @@ export type ActionLobbyInfoRequest = { action: 'lobbyInfo' }
 export type ActionStopGameRequest = { action: 'stopGame' }
 export type ActionStartGameRequest = { action: 'startGame' }
 export type ActionReadyBlind = { action: 'readyBlind' }
+export type ActionPlayerUnready = { action: 'unreadyBlind' }
 export type ActionPlayHand = {
 	action: 'playHand'
 	score: number
@@ -64,8 +65,6 @@ export type ActionPlayHand = {
 export type ActionGameInfoRequest = { action: 'gameInfo' }
 export type ActionPlayerInfoRequest = { action: 'playerInfo' }
 export type ActionEnemyInfoRequest = { action: 'enemyInfo' }
-export type ActionPlayerReady = { action: 'playerReady' }
-export type ActionPlayerUnready = { action: 'playerUnready' }
 
 export type ActionClientToServer =
 	| ActionUsername
@@ -80,7 +79,6 @@ export type ActionClientToServer =
 	| ActionGameInfoRequest
 	| ActionPlayerInfoRequest
 	| ActionEnemyInfoRequest
-	| ActionPlayerReady
 	| ActionPlayerUnready
 
 // Utility actions

--- a/Server/src/actions.ts
+++ b/Server/src/actions.ts
@@ -64,6 +64,8 @@ export type ActionPlayHand = {
 export type ActionGameInfoRequest = { action: 'gameInfo' }
 export type ActionPlayerInfoRequest = { action: 'playerInfo' }
 export type ActionEnemyInfoRequest = { action: 'enemyInfo' }
+export type ActionPlayerReady = { action: 'playerReady' }
+export type ActionPlayerUnready = { action: 'playerUnready' }
 
 export type ActionClientToServer =
 	| ActionUsername
@@ -78,6 +80,8 @@ export type ActionClientToServer =
 	| ActionGameInfoRequest
 	| ActionPlayerInfoRequest
 	| ActionEnemyInfoRequest
+	| ActionPlayerReady
+	| ActionPlayerUnready
 
 // Utility actions
 export type ActionKeepAlive = { action: 'keepAlive' }

--- a/Server/src/actions.ts
+++ b/Server/src/actions.ts
@@ -56,7 +56,7 @@ export type ActionLobbyInfoRequest = { action: 'lobbyInfo' }
 export type ActionStopGameRequest = { action: 'stopGame' }
 export type ActionStartGameRequest = { action: 'startGame' }
 export type ActionReadyBlind = { action: 'readyBlind' }
-export type ActionPlayerUnready = { action: 'unreadyBlind' }
+export type ActionUnreadyBlind = { action: 'unreadyBlind' }
 export type ActionPlayHand = {
 	action: 'playHand'
 	score: number
@@ -79,7 +79,7 @@ export type ActionClientToServer =
 	| ActionGameInfoRequest
 	| ActionPlayerInfoRequest
 	| ActionEnemyInfoRequest
-	| ActionPlayerUnready
+	| ActionUnreadyBlind
 
 // Utility actions
 export type ActionKeepAlive = { action: 'keepAlive' }

--- a/Server/src/main.ts
+++ b/Server/src/main.ts
@@ -1,7 +1,15 @@
 import net from 'node:net'
 import Client from './Client.js'
 import { actionHandlers } from './actionHandlers.js'
-import type { Action, ActionClientToServer, ActionUtility } from './actions.js'
+import type {
+	Action,
+	ActionClientToServer,
+	ActionCreateLobby,
+	ActionHandlerArgs,
+	ActionJoinLobby,
+	ActionUsername,
+	ActionUtility,
+} from './actions.js'
 
 const PORT = 8080
 
@@ -89,13 +97,38 @@ const server = net.createServer((socket) => {
 				const { action, ...actionArgs } = message
 				console.log(`Received action ${action} from ${client.id}`)
 
-				// This only works for now, once we add more arguments
-				// we'll need to refactor this
-				// Maybe add a context type that includes everything
-				// connection related?
-				Object.keys(actionArgs).length > 0
-					? actionHandlers[action]?.(actionArgs, client)
-					: actionHandlers[action]?.(client)
+				switch (action) {
+					case 'username':
+						actionHandlers.username(
+							actionArgs as ActionHandlerArgs<ActionUsername>,
+							client,
+						)
+						break
+					case 'createLobby':
+						actionHandlers.createLobby(
+							actionArgs as ActionHandlerArgs<ActionCreateLobby>,
+							client,
+						)
+						break
+					case 'joinLobby':
+						actionHandlers.joinLobby(
+							actionArgs as ActionHandlerArgs<ActionJoinLobby>,
+							client,
+						)
+						break
+					case 'lobbyInfo':
+						actionHandlers.lobbyInfo(client)
+						break
+					case 'leaveLobby':
+						actionHandlers.leaveLobby(client)
+						break
+					case 'startGame':
+						actionHandlers.startGame(client)
+						break
+					case 'keepAlive':
+						actionHandlers.keepAlive(client)
+						break
+				}
 			} catch (error) {
 				const failedToParseError = 'Failed to parse message'
 				console.error(failedToParseError, error)

--- a/Server/src/main.ts
+++ b/Server/src/main.ts
@@ -125,8 +125,11 @@ const server = net.createServer((socket) => {
 					case 'startGame':
 						actionHandlers.startGame(client)
 						break
-					case 'playerReady':
-						actionHandlers.playerReady(client)
+					case 'readyBlind':
+						actionHandlers.readyBlind(client)
+						break
+					case 'unreadyBlind':
+						actionHandlers.unreadyBlind(client)
 						break
 					case 'keepAlive':
 						actionHandlers.keepAlive(client)

--- a/Server/src/main.ts
+++ b/Server/src/main.ts
@@ -7,6 +7,7 @@ import type {
 	ActionCreateLobby,
 	ActionHandlerArgs,
 	ActionJoinLobby,
+	ActionPlayHand,
 	ActionUsername,
 	ActionUtility,
 } from './actions.js'
@@ -133,6 +134,12 @@ const server = net.createServer((socket) => {
 						break
 					case 'keepAlive':
 						actionHandlers.keepAlive(client)
+						break
+					case 'playHand':
+						actionHandlers.playHand(
+							actionArgs as ActionHandlerArgs<ActionPlayHand>,
+							client,
+						)
 						break
 				}
 			} catch (error) {

--- a/Server/src/main.ts
+++ b/Server/src/main.ts
@@ -125,6 +125,9 @@ const server = net.createServer((socket) => {
 					case 'startGame':
 						actionHandlers.startGame(client)
 						break
+					case 'playerReady':
+						actionHandlers.playerReady(client)
+						break
 					case 'keepAlive':
 						actionHandlers.keepAlive(client)
 						break

--- a/Server/src/utils.ts
+++ b/Server/src/utils.ts
@@ -1,0 +1,11 @@
+export function generateSeed(length = 5) {
+	let result = ''
+	const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+	const charactersLength = characters.length
+	let counter = 0
+	while (counter < length) {
+		result += characters.charAt(Math.floor(Math.random() * charactersLength))
+		counter += 1
+	}
+	return result
+}


### PR DESCRIPTION
This PR:
- Adds a system where players ready up before each blind, this replaces the "Next round" button on the shop
  - Note that this currently has a bug where the button on the second and third blind where the text says "Unready" even though the player hasn't clicked it yet
- Moves the seed generation server-side and provides the same seed to all players
- Implements the `playHand` action, where the players send information on their score and remaining hands whenever they play one
- Implements the (WIP) `enemyInfo` action, where the boss blind score *should* update with the score of the enemy after a hand is played
  - This is currently not working
  - I'm missing a system where the game waits for a server response after playing a hand in the boss blind, since right now you just insta-win whenever you play anything because the score to beat is 0