### PR TITLE
Virtualized/steam rich presence

### DIFF
--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -4,6 +4,8 @@
 ----------------------------------------------
 ------------MOD LOBBY-------------------------
 
+local Utils = require "Utils"
+
 G.MULTIPLAYER = {}
 
 G.LOBBY = {
@@ -37,6 +39,22 @@ function G.MULTIPLAYER.update_connection_status()
 	else
 		-- Restore them when disconnected
 		G.F_NO_ACHIEVEMENTS = START_NO_ACHIEVEMENT_VALUE
+	end
+
+	-- Game does not have locatization, and therefore does not support steam_display, status, or text right now, but we can hope
+	-- steam_player_group and steam_player_group_size is functional
+	if G.LOBBY.code then
+		G.STEAM.friends.setRichPresence('steam_display', '#FullStatus')
+		G.STEAM.friends.setRichPresence('status', '#FullStatus')
+		G.STEAM.friends.setRichPresence('text', 'In Multiplayer Lobby')
+		G.STEAM.friends.setRichPresence('steam_player_group', G.LOBBY.code)
+		G.STEAM.friends.setRichPresence('steam_player_group_size', G.LOBBY.guest.username and '2' or '1')
+	else 
+		G.STEAM.friends.setRichPresence('steam_display', '#FullStatus')
+		G.STEAM.friends.setRichPresence('status', '#FullStatus')
+		G.STEAM.friends.setRichPresence('text', 'Using Multiplayer Mod')
+		G.STEAM.friends.setRichPresence('steam_player_group', '')
+		G.STEAM.friends.setRichPresence('steam_player_group_size', '')
 	end
 
 	if G.HUD_connection_status then

--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -23,16 +23,20 @@ G.MULTIPLAYER_GAME = {
 	ready_blind_text = "Ready",
 }
 
-PREV_ACHIEVEMENT_VALUE = true
+START_NO_ACHIEVEMENT_VALUE = true
+local init_steamodded_ref = initSteamodded
+function initSteamodded()
+	init_steamodded_ref()
+	START_NO_ACHIEVEMENT_VALUE = G.F_NO_ACHIEVEMENTS
+end
+
 function G.MULTIPLAYER.update_connection_status()
-	-- Save the previous value of the achievement flag
-	PREV_ACHIEVEMENT_VALUE = G.F_NO_ACHIEVEMENTS
 	if G.LOBBY.connected then
 		-- Disable achievements when connected to server
 		G.F_NO_ACHIEVEMENTS = true
 	else
 		-- Restore them when disconnected
-		G.F_NO_ACHIEVEMENTS = PREV_ACHIEVEMENT_VALUE
+		G.F_NO_ACHIEVEMENTS = START_NO_ACHIEVEMENT_VALUE
 	end
 
 	if G.HUD_connection_status then

--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -26,9 +26,9 @@ G.MULTIPLAYER_GAME = {
 }
 
 START_NO_ACHIEVEMENT_VALUE = true
-local init_steamodded_ref = initSteamodded
-function initSteamodded()
-	init_steamodded_ref()
+local init_mods_ref = initMods
+function initMods()
+	init_mods_ref()
 	START_NO_ACHIEVEMENT_VALUE = G.F_NO_ACHIEVEMENTS
 end
 


### PR DESCRIPTION
- Got initial achievements enabled status after mods loaded
- Attempted to add steam statuses
    - This doesn't work at the moment because it requires a localization file uploaded in the game's web config, if that happens then it could start working
    - Although, it will group players who are in the same lobby on the friends list