### PR TITLE
Fix game crashes

### DIFF
--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -29,10 +29,6 @@ G.MULTIPLAYER_GAME = {
 	lives = 3,
 }
 
-G.MUTEX = {
-	wipe = false
-}
-
 PREV_ACHIEVEMENT_VALUE = true
 function G.MULTIPLAYER.update_connection_status()
 	-- Save the previous value of the achievement flag

--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -29,6 +29,10 @@ G.MULTIPLAYER_GAME = {
 	lives = 3,
 }
 
+G.MUTEX = {
+	wipe = false
+}
+
 PREV_ACHIEVEMENT_VALUE = true
 function G.MULTIPLAYER.update_connection_status()
 	-- Save the previous value of the achievement flag
@@ -71,6 +75,13 @@ function G.MULTIPLAYER.update_player_usernames()
 
 		G.FUNCS.display_lobby_main_menu_UI()
 	end
+end
+
+
+local wipe_off_ref = G.FUNCS.wipe_off
+G.FUNCS.wipe_off = function()
+	if not G.screenwipe then return end
+	wipe_off_ref()
 end
 
 ----------------------------------------------

--- a/Multiplayer/Networking/Action_Handlers.lua
+++ b/Multiplayer/Networking/Action_Handlers.lua
@@ -64,7 +64,6 @@ local function action_disconnected()
 	G.LOBBY.connected = false
 	if G.LOBBY.code then
 		G.LOBBY.code = nil
-		G.FUNCS.go_to_menu()
 	end
 	G.MULTIPLAYER.update_connection_status()
 end


### PR DESCRIPTION
- Game crashes when server times out
- Playing singleplayer crashes when using the Nebula deck
- Game crashes for the one who leaves a lobby