### PR TITLE
Remove base cash gain on blind loss

### DIFF
--- a/Multiplayer/UI/Game_UI.lua
+++ b/Multiplayer/UI/Game_UI.lua
@@ -800,6 +800,7 @@ function Game:update_new_round(dt)
 	-- Prevent player from losing
 	if G.GAME.chips - G.GAME.blind.chips < 0 then
 		G.GAME.blind.chips = -1
+		G.GAME.blind.dollars = 0
 	end
 
 	-- Prevent player from winning


### PR DESCRIPTION
- Player should still gain interest and other cash rewards
- Should act the same as small blinds on red stake

We may need to test and rethink this as it could cause a losing snowball effect for the player, might need to implement some sort of comeback mechanic