### PR TITLE
Implemented Lobby Options

### DIFF
--- a/Multiplayer/Components/Disableable_Button.lua
+++ b/Multiplayer/Components/Disableable_Button.lua
@@ -9,6 +9,7 @@ function Disableable_Button(args)
 	local enabled = enabled_table[args.enabled_ref_value]
 	args.colour = args.colour or G.C.RED
 	args.text_colour = args.text_colour or G.C.UI.TEXT_LIGHT
+  args.disabled_text = args.disabled_text or args.label
 	args.label = not enabled and args.disabled_text or args.label
 
 	local button_component = UIBox_button(args)

--- a/Multiplayer/Components/Disableable_Toggle.lua
+++ b/Multiplayer/Components/Disableable_Toggle.lua
@@ -9,11 +9,11 @@ function Disableable_Toggle(args)
 	local enabled = enabled_table[args.enabled_ref_value]
 
 	local toggle_component = create_toggle(args)
+	toggle_component.nodes[2].nodes[1].nodes[1].config.id = args.id
 	toggle_component.nodes[2].nodes[1].nodes[1].config.button = enabled and 'toggle_button' or nil
 	toggle_component.nodes[2].nodes[1].nodes[1].config.button_dist = enabled and 0.2 or nil 
 	toggle_component.nodes[2].nodes[1].nodes[1].config.hover = enabled and true or false
 	toggle_component.nodes[2].nodes[1].nodes[1].config.toggle_callback = enabled and args.callback or nil
-	toggle_component.nodes[2].nodes[1].nodes[1].config.func = enabled and 'toggle' or nil
 	return toggle_component
 end
 

--- a/Multiplayer/Components/Disableable_Toggle.lua
+++ b/Multiplayer/Components/Disableable_Toggle.lua
@@ -1,0 +1,110 @@
+--- STEAMODDED HEADER
+--- STEAMODDED SECONDARY FILE
+
+----------------------------------------------
+------------MOD DISABLEABLE TOGGLE------------
+
+function Disableable_Toggle(args)
+	local enabled_table = args.enabled_ref_table or {}
+	local enabled = enabled_table[args.enabled_ref_value]
+
+	local toggle_component = create_toggle(args)
+	toggle_component.nodes[2].nodes[1].nodes[1].config.button = enabled and 'toggle_button' or nil
+	toggle_component.nodes[2].nodes[1].nodes[1].config.button_dist = enabled and 0.2 or nil 
+	toggle_component.nodes[2].nodes[1].nodes[1].config.hover = enabled and true or false
+	toggle_component.nodes[2].nodes[1].nodes[1].config.toggle_callback = enabled and args.callback or nil
+	toggle_component.nodes[2].nodes[1].nodes[1].config.func = enabled and 'toggle' or nil
+	return toggle_component
+end
+
+return Disableable_Toggle
+
+--[[ create_toggle returns this
+  {
+    n=args.col and G.UIT.C or G.UIT.R, 
+    config={
+      align = "cm", 
+      padding = 0.1, 
+      r = 0.1,
+      colour = G.C.CLEAR, 
+      focus_args = {funnel_from = true}
+    }, 
+    nodes={
+      {
+        n=G.UIT.C, 
+        config={
+          align = "cr", 
+          minw = args.w
+        }, 
+        nodes={
+          {
+            n=G.UIT.T, 
+            config={
+              text = args.label, 
+              scale = args.label_scale, 
+              colour = G.C.UI.TEXT_LIGHT
+            }
+          },
+          {
+            n=G.UIT.B, 
+            config={
+              w = 0.1, 
+              h = 0.1
+            }
+          },
+        }
+      },
+      {
+        n=G.UIT.C, 
+        config={
+          align = "cl", 
+          minw = 0.3*args.w
+        },
+        nodes={
+          {
+            n=G.UIT.C, 
+            config={
+              align = "cm", 
+              r = 0.1, 
+              colour = G.C.BLACK
+            }, 
+            nodes={
+              {
+                n=G.UIT.C, 
+                config={
+                  align = "cm", 
+                  r = 0.1, 
+                  padding = 0.03, 
+                  minw = 0.4*args.scale, 
+                  minh = 0.4*args.scale, 
+                  outline_colour = G.C.WHITE, 
+                  outline = 1.2*args.scale, 
+                  line_emboss = 0.5*args.scale, 
+                  ref_table = args,
+                  colour = args.inactive_colour, 
+                  button = 'toggle_button', 
+                  button_dist = 0.2, 
+                  hover = true,
+                  toggle_callback = args.callback, 
+                  func = 'toggle', 
+                  focus_args = {funnel_to = true}
+                }, 
+                nodes={
+                  {
+                    n=G.UIT.O, 
+                    config={
+                      object = check
+                    }
+                  },
+                }
+              },
+            }
+          }
+        }
+      },
+    }
+  }
+]]
+
+----------------------------------------------
+------------MOD DISABLEABLE TOGGLE END--------

--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -11,7 +11,12 @@ G.LOBBY = {
 	temp_code = "",
 	code = nil,
 	type = "",
-	config = {},
+	config = {
+		no_gold_on_round_loss = true,
+		death_on_round_loss = false,
+		different_seeds = false,
+		bsh = false
+	},
 	username = "Guest",
 	host = {},
 	guest = {},

--- a/Multiplayer/Lobby.lua
+++ b/Multiplayer/Lobby.lua
@@ -14,8 +14,7 @@ G.LOBBY = {
 	config = {
 		no_gold_on_round_loss = true,
 		death_on_round_loss = false,
-		different_seeds = false,
-		bsh = false
+		different_seeds = false
 	},
 	username = "Guest",
 	host = {},

--- a/Multiplayer/Networking/Action_Handlers.lua
+++ b/Multiplayer/Networking/Action_Handlers.lua
@@ -184,6 +184,13 @@ function G.MULTIPLAYER.stop_game()
 	Client.send("action:stopGame")
 end
 
+function G.MULTIPLAYER.fail_round()
+	if G.LOBBY.config.no_gold_on_round_loss then
+		G.GAME.blind.dollars = 0
+	end
+	Client.send("action:failRound")
+end
+
 ---@param score number
 ---@param hands_left number
 function G.MULTIPLAYER.play_hand(score, hands_left)

--- a/Multiplayer/UI/Game_UI.lua
+++ b/Multiplayer/UI/Game_UI.lua
@@ -801,7 +801,7 @@ function Game:update_new_round(dt)
 		-- Prevent player from losing
 		if G.GAME.chips - G.GAME.blind.chips < 0 then
 			G.GAME.blind.chips = -1
-			G.GAME.blind.dollars = 0
+			G.MULTIPLAYER.fail_round()
 		end
 
 		-- Prevent player from winning
@@ -1438,7 +1438,7 @@ function add_round_eval_row(config)
 									n = G.UIT.O,
 									config = {
 										object = DynaText({
-											string = { G.GAME.blind.boss and " Lost a Life " or " Failed " },
+											string = { (G.GAME.blind.boss or G.LOBBY.config.death_on_round_loss) and " Lost a Life " or " Failed " },
 											colours = { G.C.FILTER },
 											shadow = true,
 											pop_in = 0,
@@ -1581,6 +1581,7 @@ function ease_lives(mod)
 	G.E_MANAGER:add_event(Event({
 		trigger = "immediate",
 		func = function()
+			if not G.hand_text_area then return end
 			local lives_UI = G.hand_text_area.ante
 			mod = mod or 0
 			local text = "+"

--- a/Multiplayer/UI/Lobby_UI.lua
+++ b/Multiplayer/UI/Lobby_UI.lua
@@ -5,6 +5,7 @@
 ------------MOD LOBBY UI----------------------
 
 local Disableable_Button = require("Components.Disableable_Button")
+local Disableable_Toggle = require("Components.Disableable_Toggle")
 
 G.HUD_connection_status = nil
 
@@ -141,7 +142,7 @@ function G.UIDEF.create_UIBox_lobby_menu()
 									align = "cm",
 								},
 								nodes = {
-									Disableable_Button({
+									UIBox_button({
 										button = "lobby_options",
 										colour = G.C.ORANGE,
 										minw = 3.15,
@@ -149,8 +150,6 @@ function G.UIDEF.create_UIBox_lobby_menu()
 										label = { "LOBBY OPTIONS" },
 										scale = text_scale * 1.2,
 										col = true,
-										enabled_ref_table = G.LOBBY,
-										enabled_ref_value = "is_host",
 									}),
 									{
 										n = G.UIT.C,
@@ -269,32 +268,129 @@ function G.UIDEF.create_UIBox_lobby_options()
 			{
 				n = G.UIT.R,
 				config = {
-					padding = 0,
+					emboss = 0.05,
+					minh = 6,
+					r = 0.1,
+					minw = 10,
+					padding = 0.2,
+					colour = G.C.BLACK,
 					align = "cm",
 				},
 				nodes = {
 					{
 						n = G.UIT.R,
 						config = {
-							padding = 0.5,
+							padding = 0.3,
 							align = "cm",
 						},
 						nodes = {
-							{
-								n = G.UIT.T,
+							not G.LOBBY.is_host and {
+								n = G.UIT.R,
 								config = {
-									text = "Not Implemented Yet",
-									shadow = true,
-									scale = 0.6,
-									colour = G.C.UI.TEXT_LIGHT,
+									padding = 0,
+									align = "cm",
 								},
+								nodes = {
+									{
+										n = G.UIT.T,
+										config = {
+											scale = 0.6,
+											shadow = true,
+											text = 'Only the Lobby Host can change these options',
+											colour = G.C.UI.TEXT_LIGHT,
+										}
+									}
+								}
+							} or nil,
+							{
+								n = G.UIT.R,
+								config = {
+									padding = 0,
+									align = "cr",
+								},
+								nodes = {
+									create_toggle({
+										enabled_ref_table = G.LOBBY,
+										enabled_ref_value = 'is_host',
+										label = "Don't get blind gold on round loss",
+										ref_table = G.LOBBY.config,
+										ref_value = "no_gold_on_round_loss",
+									}),
+								}
 							},
+							{
+								n = G.UIT.R,
+								config = {
+									padding = 0,
+									align = "cr",
+								},
+								nodes = {
+									create_toggle({
+										enabled_ref_table = G.LOBBY,
+										enabled_ref_value = 'is_host',
+										label = "Lose a life on non-PvP round loss",
+										ref_table = G.LOBBY.config,
+										ref_value = "death_on_round_loss",
+									}),
+								}
+							},
+							{
+								n = G.UIT.R,
+								config = {
+									padding = 0,
+									align = "cr",
+								},
+								nodes = {
+									create_toggle({
+										enabled_ref_table = G.LOBBY,
+										enabled_ref_value = 'is_host',
+										label = "Players have different seeds",
+										ref_table = G.LOBBY.config,
+										ref_value = "different_seeds",
+									}),
+								}
+							},
+							{
+								n = G.UIT.R,
+								config = {
+									padding = 0,
+									align = "cr",
+								},
+								nodes = {
+									create_toggle({
+										enabled_ref_table = G.LOBBY,
+										enabled_ref_value = 'is_host',
+										label = "PvP based on best single hand instead of best round",
+										ref_table = G.LOBBY.config,
+										ref_value = "bsh",
+									})
+								}
+							},
+							Disableable_Button({
+								enabled_ref_table = G.LOBBY,
+								enabled_ref_value = 'is_host',
+								button = "reset_lobby_options",
+								label = { localize("k_reset") },
+								colour = G.C.RED,
+								minw = 5,
+							}),
 						},
 					},
 				},
 			},
 		},
 	})
+end
+
+function G.FUNCS.reset_lobby_options(e)
+	G.LOBBY.config = {
+		no_gold_on_round_loss = true,
+		death_on_round_loss = false,
+		different_seeds = false,
+		bsh = false
+	}
+	G.FUNCS:exit_overlay_menu()
+	G.FUNCS.lobby_options(e)
 end
 
 function G.FUNCS.get_lobby_main_menu_UI(e)

--- a/Multiplayer/UI/Lobby_UI.lua
+++ b/Multiplayer/UI/Lobby_UI.lua
@@ -360,24 +360,6 @@ function G.UIDEF.create_UIBox_lobby_options()
 									}),
 								}
 							},
-							{
-								n = G.UIT.R,
-								config = {
-									padding = 0,
-									align = "cr",
-								},
-								nodes = {
-									Disableable_Toggle({
-										id = "bsh_toggle",
-										enabled_ref_table = G.LOBBY,
-										enabled_ref_value = 'is_host',
-										label = "PvP based on best single hand instead of best round",
-										ref_table = G.LOBBY.config,
-										ref_value = "bsh",
-										callback = toggle_lobby_options
-									})
-								}
-							},
 							Disableable_Button({
 								enabled_ref_table = G.LOBBY,
 								enabled_ref_value = 'is_host',
@@ -398,8 +380,7 @@ function G.FUNCS.reset_lobby_options(e)
 	G.LOBBY.config = {
 		no_gold_on_round_loss = true,
 		death_on_round_loss = false,
-		different_seeds = false,
-		bsh = false
+		different_seeds = false
 	}
 	G.FUNCS.exit_overlay_menu()
 	G.MULTIPLAYER.lobby_options()

--- a/Multiplayer/UI/Lobby_UI.lua
+++ b/Multiplayer/UI/Lobby_UI.lua
@@ -7,6 +7,10 @@
 local Disableable_Button = require("Components.Disableable_Button")
 local Disableable_Toggle = require("Components.Disableable_Toggle")
 
+local function toggle_lobby_options(value)
+	G.MULTIPLAYER.lobby_options()
+end
+
 G.HUD_connection_status = nil
 
 function G.UIDEF.get_connection_status_ui()
@@ -309,12 +313,14 @@ function G.UIDEF.create_UIBox_lobby_options()
 									align = "cr",
 								},
 								nodes = {
-									create_toggle({
+									Disableable_Toggle({
+										id = "no_gold_on_round_loss_toggle",
 										enabled_ref_table = G.LOBBY,
 										enabled_ref_value = 'is_host',
 										label = "Don't get blind gold on round loss",
 										ref_table = G.LOBBY.config,
 										ref_value = "no_gold_on_round_loss",
+										callback = toggle_lobby_options
 									}),
 								}
 							},
@@ -325,12 +331,14 @@ function G.UIDEF.create_UIBox_lobby_options()
 									align = "cr",
 								},
 								nodes = {
-									create_toggle({
+									Disableable_Toggle({
+										id = "death_on_round_loss_toggle",
 										enabled_ref_table = G.LOBBY,
 										enabled_ref_value = 'is_host',
 										label = "Lose a life on non-PvP round loss",
 										ref_table = G.LOBBY.config,
 										ref_value = "death_on_round_loss",
+										callback = toggle_lobby_options
 									}),
 								}
 							},
@@ -341,12 +349,14 @@ function G.UIDEF.create_UIBox_lobby_options()
 									align = "cr",
 								},
 								nodes = {
-									create_toggle({
+									Disableable_Toggle({
+										id = "different_seeds_toggle",
 										enabled_ref_table = G.LOBBY,
 										enabled_ref_value = 'is_host',
 										label = "Players have different seeds",
 										ref_table = G.LOBBY.config,
 										ref_value = "different_seeds",
+										callback = toggle_lobby_options
 									}),
 								}
 							},
@@ -357,12 +367,14 @@ function G.UIDEF.create_UIBox_lobby_options()
 									align = "cr",
 								},
 								nodes = {
-									create_toggle({
+									Disableable_Toggle({
+										id = "bsh_toggle",
 										enabled_ref_table = G.LOBBY,
 										enabled_ref_value = 'is_host',
 										label = "PvP based on best single hand instead of best round",
 										ref_table = G.LOBBY.config,
 										ref_value = "bsh",
+										callback = toggle_lobby_options
 									})
 								}
 							},
@@ -389,8 +401,8 @@ function G.FUNCS.reset_lobby_options(e)
 		different_seeds = false,
 		bsh = false
 	}
-	G.FUNCS:exit_overlay_menu()
-	G.FUNCS.lobby_options(e)
+	G.FUNCS.exit_overlay_menu()
+	G.MULTIPLAYER.lobby_options()
 end
 
 function G.FUNCS.get_lobby_main_menu_UI(e)

--- a/Multiplayer/UI/Main_Menu.lua
+++ b/Multiplayer/UI/Main_Menu.lua
@@ -99,16 +99,6 @@ function G.UIDEF.create_UIBox_create_lobby_button()
 														},
 													},
 												},
-												create_toggle({
-													label = "Lose lives on round loss",
-													ref_table = G.LOBBY.config,
-													ref_value = "death_on_round_loss",
-												}),
-												create_toggle({
-													label = "Different seeds",
-													ref_table = G.LOBBY.config,
-													ref_value = "different_seeds",
-												}),
 												UIBox_button({
 													label = { "Start Lobby" },
 													colour = G.C.RED,

--- a/Server/README.md
+++ b/Server/README.md
@@ -97,6 +97,9 @@ endPvP: lost
 
 ---
 
+lobbyOptions: {any number of options recognized by the client}
+- Updates guest clients when host changes options, should be sent when client connects and when options change
+
 ### Client to Server
 
 username: username
@@ -166,6 +169,11 @@ playerInfo
 
 enemyInfo
 - Request an enemyInfo update.
+
+---
+
+lobbyOptions: {any number of options recognized by the client}
+- Updates the server-side log of lobby options, should be sent on lobby start and when options are changed
 
 ### Utility
 

--- a/Server/README.md
+++ b/Server/README.md
@@ -175,6 +175,11 @@ enemyInfo
 lobbyOptions: {any number of options recognized by the client}
 - Updates the server-side log of lobby options, should be sent on lobby start and when options are changed
 
+---
+
+failRound
+- Declares the client lost a round
+
 ### Utility
 
 keepAlive

--- a/Server/src/Lobby.ts
+++ b/Server/src/Lobby.ts
@@ -22,6 +22,7 @@ class Lobby {
 	host: Client | null
 	guest: Client | null
 	gameMode: GameMode
+	options: { [key: string]: string }
 
 	// Attrition is the default game mode
 	constructor(host: Client, gameMode: GameMode = 'attrition') {
@@ -33,6 +34,7 @@ class Lobby {
 		this.host = host
 		this.guest = null
 		this.gameMode = gameMode
+		this.options = {}
 
 		host.setLobby(this)
 		host.sendAction({ action: 'joinedLobby', code: this.code })
@@ -73,6 +75,7 @@ class Lobby {
 		this.guest = client
 		client.setLobby(this)
 		client.sendAction({ action: 'joinedLobby', code: this.code })
+		client.sendAction({ action: 'lobbyOptions', ...this.options })
 		this.broadcastLobbyInfo()
 	}
 
@@ -108,6 +111,11 @@ class Lobby {
 		if (this.guest) this.guest.lives = lives
 
 		this.broadcastAction({ action: 'playerInfo', lives })
+	}
+
+	setOptions = (options: { [key: string]: string }) => {
+		this.options = options
+		this.guest?.sendAction({ action: 'lobbyOptions', ...options })
 	}
 }
 

--- a/Server/src/Lobby.ts
+++ b/Server/src/Lobby.ts
@@ -22,7 +22,7 @@ class Lobby {
 	host: Client | null
 	guest: Client | null
 	gameMode: GameMode
-	options: { [key: string]: string }
+	options: { [key: string]: any }
 
 	// Attrition is the default game mode
 	constructor(host: Client, gameMode: GameMode = 'attrition') {
@@ -114,7 +114,13 @@ class Lobby {
 	}
 
 	setOptions = (options: { [key: string]: string }) => {
-		this.options = options
+		for (const key of Object.keys(options)) {
+			if (options[key] == "true" || options[key] == "false") {
+				this.options[key] = options[key] == "true"
+			} else{
+				this.options[key] = options[key]
+			}
+		}
 		this.guest?.sendAction({ action: 'lobbyOptions', ...options })
 	}
 }

--- a/Server/src/actionHandlers.ts
+++ b/Server/src/actionHandlers.ts
@@ -77,7 +77,7 @@ const startGameAction = (client: Client) => {
 	lobby.broadcastAction({
 		action: 'startGame',
 		deck: 'c_multiplayer_1',
-		seed: generateSeed(),
+		seed: lobby.options.different_seeds? undefined : generateSeed(),
 	})
 }
 
@@ -114,8 +114,6 @@ const playHandAction = (
 		return
 	}
 
-	// Should this be additive or just
-	// the latest score?
 	client.score = score
 	client.handsLeft =
 		typeof handsLeft === 'number' ? handsLeft : Number(handsLeft)
@@ -188,6 +186,30 @@ const lobbyOptionsAction = (options: any, client: Client) => {
 	client.lobby?.setOptions(options)
 }
 
+const failRoundAction = (client: Client) => {
+	const lobby = client.lobby
+
+	if (!lobby) return
+
+	client.lives -= 1
+	client.sendAction({ action: 'playerInfo', lives: client.lives })
+
+	if (client.lives === 0) {
+		let gameLoser = null
+		let gameWinner = null
+		if (client.id === lobby.host?.id) {
+			gameLoser = lobby.host
+			gameWinner = lobby.guest
+		} else {
+			gameLoser = lobby.guest
+			gameWinner = lobby.host
+		}
+
+		gameWinner?.sendAction({ action: 'winGame' })
+		gameLoser?.sendAction({ action: 'loseGame' })
+	}
+}
+
 // Declared partial for now untill all action handlers are defined
 export const actionHandlers = {
 	username: usernameAction,
@@ -202,4 +224,5 @@ export const actionHandlers = {
 	playHand: playHandAction,
 	stopGame: stopGameAction,
 	lobbyOptions: lobbyOptionsAction,
+	failRound: failRoundAction,
 } satisfies Partial<ActionHandlers>

--- a/Server/src/actionHandlers.ts
+++ b/Server/src/actionHandlers.ts
@@ -184,6 +184,10 @@ const stopGameAction = (client: Client) => {
 	client.lobby?.broadcastAction({ action: 'stopGame' })
 }
 
+const lobbyOptionsAction = (options: any, client: Client) => {
+	client.lobby?.setOptions(options)
+}
+
 // Declared partial for now untill all action handlers are defined
 export const actionHandlers = {
 	username: usernameAction,
@@ -197,4 +201,5 @@ export const actionHandlers = {
 	unreadyBlind: unreadyBlindAction,
 	playHand: playHandAction,
 	stopGame: stopGameAction,
+	lobbyOptions: lobbyOptionsAction,
 } satisfies Partial<ActionHandlers>

--- a/Server/src/actions.ts
+++ b/Server/src/actions.ts
@@ -32,6 +32,8 @@ export type ActionEnemyInfo = {
 }
 export type ActionEndPvP = { action: 'endPvP'; lost: boolean }
 
+export type ActionLobbyOptions = { action: 'lobbyOptions' }
+
 export type ActionServerToClient =
 	| ActionConnected
 	| ActionError
@@ -46,6 +48,7 @@ export type ActionServerToClient =
 	| ActionPlayerInfo
 	| ActionEnemyInfo
 	| ActionEndPvP
+	| ActionLobbyOptions
 	| ActionKeepAlive
 	| ActionKeepAliveAck
 
@@ -82,6 +85,7 @@ export type ActionClientToServer =
 	| ActionPlayerInfoRequest
 	| ActionEnemyInfoRequest
 	| ActionUnreadyBlind
+	| ActionLobbyOptions
 
 // Utility actions
 export type ActionKeepAlive = { action: 'keepAlive' }

--- a/Server/src/actions.ts
+++ b/Server/src/actions.ts
@@ -70,6 +70,7 @@ export type ActionPlayHand = {
 export type ActionGameInfoRequest = { action: 'gameInfo' }
 export type ActionPlayerInfoRequest = { action: 'playerInfo' }
 export type ActionEnemyInfoRequest = { action: 'enemyInfo' }
+export type ActionFailRound = { action: 'failRound' }
 
 export type ActionClientToServer =
 	| ActionUsername
@@ -86,6 +87,7 @@ export type ActionClientToServer =
 	| ActionEnemyInfoRequest
 	| ActionUnreadyBlind
 	| ActionLobbyOptions
+	| ActionFailRound
 
 // Utility actions
 export type ActionKeepAlive = { action: 'keepAlive' }

--- a/Server/src/main.ts
+++ b/Server/src/main.ts
@@ -158,6 +158,9 @@ const server = net.createServer((socket) => {
 					case 'stopGame':
 						actionHandlers.stopGame(client)
 						break
+					case 'lobbyOptions':
+						actionHandlers.lobbyOptions(actionArgs, client)
+						break
 				}
 			} catch (error) {
 				const failedToParseError = 'Failed to parse message'

--- a/Server/src/main.ts
+++ b/Server/src/main.ts
@@ -161,6 +161,9 @@ const server = net.createServer((socket) => {
 					case 'lobbyOptions':
 						actionHandlers.lobbyOptions(actionArgs, client)
 						break
+					case 'failRound':
+						actionHandlers.failRound(client)
+						break
 				}
 			} catch (error) {
 				const failedToParseError = 'Failed to parse message'


### PR DESCRIPTION
Moved the lobby options that were on the description of the gamemodes before creating a lobby to the lobby options menu inside a lobby. Current options are:
- Don't get blind gold on round loss (on by default)
- Lose a life on regular round loss 
- Different seeds

Note: I also attempted to add "Best Single Hand" which would mean the player's scores in PvP would not be cumulative, and would only be as high as their highest scoring hand. This requires a more extensive implementation than the other features in this PR, so I have removed it for now and we can implement it in a later PR if desired.