### PR TITLE
fix(client): duplicating end_round

### DIFF
--- a/Multiplayer/UI/Game_UI.lua
+++ b/Multiplayer/UI/Game_UI.lua
@@ -854,7 +854,6 @@ function Game:update_hand_played(dt)
 	if G.MULTIPLAYER_GAME.end_pvp then
 		G.STATE_COMPLETE = false
 		G.STATE = G.STATES.NEW_ROUND
-		G.MULTIPLAYER_GAME.end_pvp = false
 	end
 end
 


### PR DESCRIPTION
It is like the most simple fix ever but it took me a lot of hours to debug, i learned a lot.

I know that the server will be rewritten, so i decided to fix this bug on the client side. The situation happens because end_pvp msg is sent twice, and because update_played_hand runs on every frame, the G.STATES.NEW_ROUND get run twice. 

Since in the shop menu, the end_pvp will be set back to false, so the update hand function doesn't have to set end_pvp to false.  Therefore deleting end_pvp = false here will be fine.

P.S: update selected hand should have the same problem, but i dont know how to produce a bug like that. 