### PR TITLE
ops: automatic release, luarc json for lua language server, and ignore username change

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,73 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "*.*.*" # Matches tags like 1.0.0, 2.3.4, etc.
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo "::set-output name=version::$VERSION"
+
+      - name: Prepare release assets
+        env:
+          CONFIG_URL: ${{ secrets.CONFIG_URL }}
+          CONFIG_PORT: ${{ secrets.CONFIG_PORT }}
+        run: |
+          mkdir -p release/Multiplayer
+          cp -r Multiplayer/* release/Multiplayer/
+          rm release/Multiplayer/example.Config.lua
+
+          # Create the config.lua file
+          echo "----------------------------------------------" > release/Multiplayer/config.lua
+          echo "------------MOD CONFIG------------------------" >> release/Multiplayer/config.lua
+          echo "" >> release/Multiplayer/config.lua
+          echo "Config = {}" >> release/Multiplayer/config.lua
+          echo "" >> release/Multiplayer/config.lua
+          echo "Config.URL = '${CONFIG_URL}'" >> release/Multiplayer/config.lua
+          echo "Config.PORT = ${CONFIG_PORT}" >> release/Multiplayer/config.lua
+          echo "" >> release/Multiplayer/config.lua
+          echo "return Config" >> release/Multiplayer/config.lua
+          echo "" >> release/Multiplayer/config.lua
+          echo "----------------------------------------------" >> release/Multiplayer/config.lua
+          echo "------------MOD CONFIG END--------------------" >> release/Multiplayer/config.lua
+
+          # Create the Version.lua file with the version number
+          VERSION=${{ steps.extract_version.outputs.version }}
+          echo "return \"$VERSION\"" > release/Multiplayer/Version.lua
+
+          # Zip the Multiplayer directory with the desired name
+          cd release
+          zip -r Multiplayer-beta-$VERSION.zip Multiplayer
+          cd ..
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.extract_version.outputs.version }}
+          release_name: v${{ steps.extract_version.outputs.version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/Multiplayer-beta-${{ steps.extract_version.outputs.version }}.zip
+          asset_name: Multiplayer-beta-${{ steps.extract_version.outputs.version }}.zip
+          asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Config.lua
 Server/dist
 .vscode
 Multiplayer/Saved/username.txt
+Version.lua

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Server/dist
 .vscode
 Multiplayer/Saved/username.txt
 Version.lua
+ref

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 Config.lua
 Server/dist
 .vscode
+Multiplayer/Saved/username.txt

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,14 @@
+{
+  "Lua.runtime.version": "LuaJIT",
+  "Lua.workspace.library": {
+    "./ref/balatro_ref": true,
+    "${3rd}/love2d/library": true
+  },
+  "Lua.workspace.ignoreDir": [
+    "./ref/balatro_ref"
+  ],
+  "diagnostics.disable": [
+    "lowercase-global",
+    "duplicate-set-field"
+  ]
+}

--- a/Multiplayer/UI/Main_Menu.lua
+++ b/Multiplayer/UI/Main_Menu.lua
@@ -2,8 +2,12 @@
 ------------MOD MAIN MENU---------------------
 
 local Utils = require("Utils")
+local success, version = pcall(require, "Version")
+if not success then
+	version = "DEV"
+end
 
-MULTIPLAYER_VERSION = "0.1.3-MULTIPLAYER"
+MULTIPLAYER_VERSION = version .. "-MULTIPLAYER"
 
 local game_main_menu_ref = Game.main_menu
 ---@diagnostic disable-next-line: duplicate-set-field

--- a/Server/src/actionHandlers.ts
+++ b/Server/src/actionHandlers.ts
@@ -228,7 +228,7 @@ const versionAction = (
 	{ version }: ActionHandlerArgs<ActionVersion>,
 	client: Client,
 ) => {
-	if (version !== serverVersion) {
+	if (version !== serverVersion && version.startsWith("DEV")) {
 		client.sendAction({ action: "error", message: `[WARN] Server expecting version ${serverVersion}` });
 	}
 };


### PR DESCRIPTION
# Things you should set up on your end

You should symlink the balatro-ref to ./ref/balatro-ref

also use `git update-index --assume-unchanged ./Multiplayer/Saved/username.txt` to ignore further change, this allows me to symlink the Multiplayer folder to the mods folder to save space and maintain a single copy

also tell me if you want me to have a smaller size pr, that focus on 1 thing or group them like this. As long as they are focusing on the same topic, i think it is fine.

and @V-rtualized  you will have to add CONFIG_URL and CONFIG_PORT, in the secrets and variables section of the repository settings. 

like this: 
![image](https://github.com/V-rtualized/balatro-multiplayer/assets/79507956/49cd6893-78e3-406f-9b88-0fab1a485f3b)

# Things this PR does
1. A draft release will be made when someone tag a commit with a tag that have the format *.*.*, it will remove the example.Config.lua and add version.lua and config.lua in it
2. Ignoring username.txt change from now on
3. Set up the lua language server for linting purposes.