### PR TITLE
Added build script for MSVC dll

### DIFF
--- a/GoLib/build.ps1
+++ b/GoLib/build.ps1
@@ -1,0 +1,3 @@
+go build -o ./bin/multiplayer-windows-msvc.a -buildmode=c-archive main.go
+cl /MD /c multiplayer-windows-msvc.c /Fobin\ /link ./bin/multiplayer-windows-msvc.a
+cl /LD /MD /Fe"./bin/multiplayer-windows-msvc.dll" /Fo"./bin/multiplayer-windows-msvc.obj" multiplayer-windows-msvc.c /link /DEF:multiplayer-windows-msvc.def ./bin/multiplayer-windows-msvc.a

--- a/GoLib/build.sh
+++ b/GoLib/build.sh
@@ -1,2 +1,1 @@
 env CGO_ENABLED=1 go build -buildmode=c-shared -o ./bin/multiplayer.so main.go
-env GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CXX=x86_64-w64-mingw32-g++ CC=x86_64-w64-mingw32-gcc go build -buildmode=c-shared -o ./bin/multiplayer.dll main.go

--- a/GoLib/cgo.c
+++ b/GoLib/cgo.c
@@ -1,0 +1,13 @@
+#ifndef NO_CGO_LIB
+
+__pragma(comment(lib, "legacy_stdio_definitions.lib"));
+
+// https://github.com/golang/go/issues/42190#issuecomment-1507839987
+void _rt0_amd64_windows_lib();
+
+__pragma(section(".CRT$XCU", read));
+__declspec(allocate(".CRT$XCU")) void (*init_lib)() = _rt0_amd64_windows_lib;
+
+__pragma(comment(linker, "/include:init_lib"));
+
+#endif

--- a/GoLib/multiplayer-windows-msvc.c
+++ b/GoLib/multiplayer-windows-msvc.c
@@ -1,0 +1,2 @@
+#include "./bin/multiplayer-windows-msvc.h"
+#include "cgo.c"

--- a/GoLib/multiplayer-windows-msvc.def
+++ b/GoLib/multiplayer-windows-msvc.def
@@ -1,0 +1,5 @@
+EXPORTS
+	_rt0_amd64_windows_lib
+	luaEntryPoint
+    getLobbyCode
+    getUsername


### PR DESCRIPTION
The build.ps1 must be ran through the Developer PowerShell for VS 2022.
Install the MS Build tools [here](https://aka.ms/vs/17/release/vs_BuildTools.exe).
From the dev command line run `Powershell -ExecutionPolicy Bypass -File build.ps1` to bypass the execution policy.